### PR TITLE
Fixed api.login to work with new gmusicapi

### DIFF
--- a/common.py
+++ b/common.py
@@ -108,7 +108,7 @@ def open_api():
     password = getpass.getpass(username + '\'s password: ')
     
     api = Mobileclient()
-    if not api.login(username, password):
+    if not api.login(username, password, Mobileclient.FROM_MAC_ADDRESS):
         log('ERROR unable to login')
         time.sleep(3)
         exit()


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "ExportLists.py", line 17, in <module>
    api = open_api()
  File "/Users/cubic/Downloads/gmusic-playlist-master/common.py", line 111, in open_api
    if not api.login(username, password):
TypeError: login() takes exactly 4 arguments (3 given)
```