### PR TITLE
Don't fail on csv's that supply additional fields that we're not using

### DIFF
--- a/common.py
+++ b/common.py
@@ -121,6 +121,8 @@ def create_details(details_list):
     if len(details_list) < 2:
         return details
     for pos, nfo in enumerate(details_list):
+        if len(track_info_order) <= pos:
+            continue
         details[track_info_order[pos]] = nfo.strip()
     return details
 


### PR DESCRIPTION
This fixes bug #25

I don't want to have to strip off all fields of a generated csv, this will allow that.